### PR TITLE
fix: modularity for human's bodyparts

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_EMPTY(customizable_races)
 
 /datum/species/human
 	mutant_bodyparts = list()
-	//default_mutant_bodyparts = list("ears" = "None", "tail" = "None", "wings" = "None") //Skyrat220 EDIT
+	default_mutant_bodyparts = list("ears" = "None", "tail" = "None", "wings" = "None")
 
 /datum/species/mush
 	mutant_bodyparts = list()

--- a/modular_ss220/modules/mutant_parts/species.dm
+++ b/modular_ss220/modules/mutant_parts/species.dm
@@ -1,0 +1,2 @@
+/datum/species/human
+	default_mutant_bodyparts = list()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7017,5 +7017,6 @@
 #include "modular_skyrat\modules\xenos_skyrat_redo\code\xeno_types\warrior.dm"
 #include "modular_ss220\modules\jobs\jobs.dm"
 #include "modular_ss220\modules\mutant_parts\body_size.dm"
+#include "modular_ss220\modules\mutant_parts\species.dm"
 #include "modular_ss220\modules\mutant_parts\taur.dm"
 // END_INCLUDE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Делает https://github.com/ss220club/Skyrat-tg/pull/4 модульным

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: Human's mutant bodyparts override in module
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
