### PR TITLE
Make humans without tts_seed fallback to Arthas

### DIFF
--- a/modular_ss220/modules/tts/code/tts_mob_Hear.dm
+++ b/modular_ss220/modules/tts/code/tts_mob_Hear.dm
@@ -37,7 +37,7 @@
 		traits &= TTS_TRAIT_PITCH_WHISPER
 
 	var/mob/living/carbon/human/human_speaker = real_speaker
-	var/tts_seed = istype(human_speaker) ? human_speaker.tts_seed : "Arthas"
+	var/tts_seed = istype(human_speaker) && human_speaker.tts_seed || "Arthas"
 
 	var/message_tts = translate_language(language = message_language, raw_message = raw_message)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Добавляет фоллбек на голос Артаса, если голос не найден в мобе
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Голоса мидраундовым антагам вместо тишины
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed humans without tts_seed being mute
/:cl:
