### PR TITLE
Add ability to select atom/movable TTS voice

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -103,6 +103,7 @@
 
 // /atom/movable
 #define VV_HK_DEADCHAT_PLAYS "deadchat_plays"
+#define VV_HK_SELECT_TTS_VOICE "select_tts_voice"
 
 // /obj
 #define VV_HK_OSAY "osay"

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1597,6 +1597,7 @@
 	VV_DROPDOWN_OPTION(VV_HK_EDIT_PARTICLES, "Edit Particles")
 	VV_DROPDOWN_OPTION(VV_HK_DEADCHAT_PLAYS, "Start/Stop Deadchat Plays")
 	VV_DROPDOWN_OPTION(VV_HK_ADD_FANTASY_AFFIX, "Add Fantasy Affix")
+	VV_DROPDOWN_OPTION(VV_HK_SELECT_TTS_VOICE, "Select TTS voice")
 
 /atom/movable/vv_do_topic(list/href_list)
 	. = ..()
@@ -1624,6 +1625,11 @@
 		to_chat(usr, span_notice("Deadchat now control [src]."))
 		log_admin("[key_name(usr)] has added deadchat control to [src]")
 		message_admins(span_notice("[key_name(usr)] has added deadchat control to [src]"))
+
+	if(href_list[VV_HK_SELECT_TTS_VOICE] && check_rights(R_VAREDIT))
+		var/selected_tts_seed = tgui_input_list(usr, "Select a TTS voice to change to", "[src.name] TTS voice selection", SStts.tts_seeds_names)
+		if(selected_tts_seed)
+			tts_seed = selected_tts_seed
 
 /**
 * A wrapper for setDir that should only be able to fail by living mobs.

--- a/modular_ss220/modules/tts/code/tts_mob_Hear.dm
+++ b/modular_ss220/modules/tts/code/tts_mob_Hear.dm
@@ -46,12 +46,9 @@
 	if(is_speaker_whispering)
 		traits &= TTS_TRAIT_PITCH_WHISPER
 
-	var/mob/mob_speaker = real_speaker
-	var/tts_seed = istype(mob_speaker) && mob_speaker.tts_seed || "Arthas"
-
 	var/message_tts = translate_language(language = message_language, raw_message = raw_message)
 
-	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(tts_cast), speaker, src, message_tts, tts_seed, !radio_freq, effect, traits)
+	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(tts_cast), speaker, src, message_tts, real_speaker.tts_seed, !radio_freq, effect, traits)
 
 /mob/living/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, list/message_mods, message_range)
 	var/static/regex/plus_sign_replace = new(@"\+", "g")

--- a/modular_ss220/modules/tts/code/tts_seed.dm
+++ b/modular_ss220/modules/tts/code/tts_seed.dm
@@ -16,8 +16,8 @@
 /datum/preference/text/tts_seed/create_default_value()
 	return "Arthas"
 
-/// Any mob
-/mob
+/// Any movable atom
+/atom/movable
 	var/tts_seed
 
 /datum/preference/text/tts_seed/apply_to_human(mob/living/carbon/human/target, value)

--- a/modular_ss220/modules/tts/code/tts_subsystem.dm
+++ b/modular_ss220/modules/tts/code/tts_subsystem.dm
@@ -498,13 +498,13 @@ SUBSYSTEM_DEF(tts)
 	if(sanitized_messages_caching)
 		sanitized_messages_cache[hash] = .
 
-/proc/tts_cast(atom/speaker, mob/listener, message, seed_name, is_local = TRUE, effect = SOUND_EFFECT_NONE, traits = TTS_TRAIT_RATE_FASTER, preSFX = null, postSFX = null)
+/proc/tts_cast(atom/speaker, mob/listener, message, seed_name = "Arthas", is_local = TRUE, effect = SOUND_EFFECT_NONE, traits = TTS_TRAIT_RATE_FASTER, preSFX = null, postSFX = null)
 	SStts.get_tts(speaker, listener, message, seed_name, is_local, effect, traits, preSFX, postSFX)
 
 /proc/tts_word_replacer(word)
 	var/static/list/tts_replacement_list
 	if(!tts_replacement_list)
-		tts_replacement_list = list(\
+		tts_replacement_list = list(
 			"нт" = "Эн Тэ",
 			"смо" = "Эс Мэ О",
 			"гп" = "Гэ Пэ",
@@ -568,6 +568,7 @@ SUBSYSTEM_DEF(tts)
 			"трейзен" = "трэйзэн",
 			"нанотрейзен" = "нанотрэйзэн",
 			"мед" = "м ед",
+			"меде" = "м еде",
 			"кз" = "Кэ Зэ",
 		)
 	var/match = tts_replacement_list[lowertext(word)]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Добавляет мувейбл атомам `tts_seed` с возможностью выбора голоса в VV с помощью TGUI.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Админы смогут говорить бутылкой голосом Эвелинн.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

https://discord.com/channels/1097181193939730453/1097521716013568011/1105199389649141820

## Changelog

:cl:
add: Added "Select TTS voice" verb to movable atoms VV
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
